### PR TITLE
newrelic: add the config

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,15 @@
+---
+production:
+  agent_enabled: true
+  error_collector:
+    capture_source: true
+    enabled: true
+    ignore_errors: ActionController::RoutingError
+  apdex_t: 0.5
+  ssl: true
+  monitor_mode: true
+  license_key: <%= ENV["NEW_RELIC_LICENSE_KEY"] %>
+  developer_mode: false
+  app_name: <%= ENV["NEW_RELIC_APP_NAME"] %>
+  capture_params: false
+  log_level: info


### PR DESCRIPTION
I noticed that vellup was missing data in the newrelic config file.  This adds that, which will allow your stats to show up now.
